### PR TITLE
Standardize package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,27 @@
 {
   "name": "suitcss-utils-after",
-  "description": "Trailing offset utilities for SUIT CSS",
   "version": "1.0.1",
-  "style": "index.css",
+  "description": "Trailing offset utilities for SUIT CSS",
+  "keywords": [
+    "browser",
+    "css-utilities",
+    "offset",
+    "style",
+    "suitcss"
+  ],
+  "homepage": "https://github.com/suitcss/utils-after#readme",
+  "bugs": "https://github.com/suitcss/utils-after/labels/bug",
+  "license": "MIT",
+  "author": "Nicolas Gallagher",
   "files": [
     "index.css",
     "index.js",
     "lib"
   ],
-  "devDependencies": {
-    "stylelint-config-suitcss": "^4.0.0",
-    "suitcss-components-test": "*",
-    "suitcss-preprocessor": "^1.0.0"
+  "style": "index.css",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/suitcss/utils-after.git"
   },
   "scripts": {
     "build": "npm run setup && npm run preprocess",
@@ -23,15 +33,10 @@
     "watch": "npm run preprocess-test -- -w -v",
     "test": "npm run lint"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/suitcss/utils-after.git"
-  },
-  "keywords": [
-    "browser",
-    "css-utilities",
-    "offset",
-    "suitcss",
-    "style"
-  ]
+  "devDependencies": {
+    "stylelint": "^5.4.0",
+    "stylelint-config-suitcss": "^5.0.0",
+    "suitcss-components-test": "*",
+    "suitcss-preprocessor": "^2.0.0"
+  }
 }


### PR DESCRIPTION
I noticed some inconsistencies and omissions in suit package info, so I tidied up:
- Arrange the package objects to match the order found in https://docs.npmjs.com/files/package.json.
- Add a `homepage` object with a link to the project’s readme on GitHub.
- Add a `bugs` object with a link to the project’s issues labeled `bug` on GitHub.
- Add an `author` object with the name of the project’s author.
- Clean up any mistakes or omissions
